### PR TITLE
Migrate extension to MV3

### DIFF
--- a/DiscoEnhancements/background.js
+++ b/DiscoEnhancements/background.js
@@ -30,46 +30,49 @@ chrome.runtime.onInstalled.addListener(function() {
   chrome.storage.local.set({
     taxonomy_attrs: true
   });
+  chrome.action.disable();
 });
 
 // Listen for tab update
 // TODO: Better Appliance matching so the extension doesn't trigger on a regular website
 chrome.tabs.onUpdated.addListener(function(id, info, tab) {
-  chrome.tabs.executeScript(tab.id, {
-    // Gets bmcAppInfo.yodelBlock (v10.2) or productTitle (v11+)
-    "code": "document.querySelectorAll('div.bmcAppInfo.yodelBlock, span.productTitle')[0].textContent;"
-  }, function(result) {
-    var isDisco = result;
+  chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: function() {
+      const el = document.querySelectorAll('div.bmcAppInfo.yodelBlock, span.productTitle')[0];
+      return el ? el.textContent : null;
+    }
+  }, function(injectionResult) {
+    const isDisco = injectionResult && injectionResult[0] ? injectionResult[0].result : null;
 
     // productTitle is a bit generic so do a check for "Discovery" in title text
     if (isDisco && isDisco.includes("Discovery")) {
-      chrome.pageAction.show(tab.id);
-      chrome.storage.local.set({
-        is_disco: true
-      });
+      chrome.action.enable(tab.id);
+      chrome.storage.local.set({ is_disco: true });
 
       // If this is homepage, we want to grab and store the dashboards menu
-      chrome.tabs.executeScript(tab.id, {
-        "code": "document.getElementById('dashboards');"
-        //"code": "document.getElementById('sideBarHolder');"
-      }, function(result) {
-        var dash = result;
-        if (dash) {
-          chrome.tabs.executeScript(tab.id, {
-            //"code": "document.getElementById('dashboards').innerHTML;"
-            "code": "document.getElementById('sideBarHolder').innerHTML;"
-          }, function(result) {
-            var dash_menu = result;
-            chrome.storage.local.set({
-              dashboard: dash_menu
-            });
-          })
+      chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: function() {
+          return document.getElementById('dashboards');
         }
-      })
-    } else {
-      chrome.storage.local.set({
-        is_disco: false
+      }, function(result) {
+        const dash = result && result[0] ? result[0].result : null;
+        if (dash) {
+          chrome.scripting.executeScript({
+            target: { tabId: tab.id },
+            func: function() {
+              return document.getElementById('sideBarHolder').innerHTML;
+            }
+          }, function(res) {
+            const dash_menu = res && res[0] ? res[0].result : null;
+            chrome.storage.local.set({ dashboard: dash_menu });
+          });
+        }
       });
+    } else {
+      chrome.action.disable(tab.id);
+      chrome.storage.local.set({ is_disco: false });
     }
-  })
+  });
 });

--- a/DiscoEnhancements/manifest.json
+++ b/DiscoEnhancements/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Disco Enhancements for BMC Discovery (DEV)",
   "description": "This exension provides some powerful enhancements to the BMC Discovery UI.",
@@ -8,20 +8,21 @@
   "short_name": "Disco Enhancements",
 
   "icons": {
-    "128": "images/icon.png"
+    "128": "images/icon128.png"
   },
 
   "permissions": [
-    "http://*/*",
-    "https://*/*",
     "activeTab",
-    "storage"
+    "storage",
+    "scripting"
+  ],
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
   ],
 
   "background": {
-    "run_at": "document_end",
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
 
   "content_scripts": [{
@@ -33,9 +34,13 @@
     "genericquery.html"
   ],
 
-  "page_action": {
+  "action": {
     "default_title": "Disco Enhancements",
-    "default_icon": "images/icon.png",
+    "default_icon": {
+      "16": "images/icon.png",
+      "48": "images/icon.png",
+      "128": "images/icon128.png"
+    },
     "default_popup": "popup.html"
   }
 

--- a/DiscoEnhancements/popup.js
+++ b/DiscoEnhancements/popup.js
@@ -137,24 +137,27 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  chrome.tabs.executeScript(null, {
-    "code": "document.getElementById('debug');"
-  }, function(result) {
-    var isDebug = result[0];
+  chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+    chrome.scripting.executeScript({
+      target: { tabId: tabs[0].id },
+      func: function() { return document.getElementById('debug'); }
+    }, function(result) {
+      var isDebug = result && result[0] ? result[0].result : null;
 
-    if (isDebug) {
-      chrome.storage.local.set({
-        debug_text: true
-      });
-      document.getElementById('debugText').innerHTML = "Debug is ON";
-      document.getElementById('setDebug').value = "Turn Off Debug";
-    } else {
-      chrome.storage.local.set({
-        debug_text: false
-      });
-      document.getElementById('debugText').innerHTML = null;
-      document.getElementById('setDebug').value = "Turn On Debug";
-    }
+      if (isDebug) {
+        chrome.storage.local.set({
+          debug_text: true
+        });
+        document.getElementById('debugText').innerHTML = "Debug is ON";
+        document.getElementById('setDebug').value = "Turn Off Debug";
+      } else {
+        chrome.storage.local.set({
+          debug_text: false
+        });
+        document.getElementById('debugText').innerHTML = null;
+        document.getElementById('setDebug').value = "Turn On Debug";
+      }
+    });
   });
 
   document.getElementById("setDebug").onclick = function() {


### PR DESCRIPTION
## Summary
- upgrade manifest to MV3 with action API and service worker
- migrate background and popup scripts to `chrome.scripting` API
- use `chrome.action.enable/disable` in place of pageAction

## Testing
- `node -c DiscoEnhancements/background.js`
- `node -c DiscoEnhancements/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_686d33420e8883268f5d1abd032aee23