### PR TITLE
Remove run_at from manifest background

### DIFF
--- a/DiscoEnhancements/manifest.json
+++ b/DiscoEnhancements/manifest.json
@@ -19,7 +19,6 @@
   ],
 
   "background": {
-    "run_at": "document_end",
     "scripts": ["background.js"],
     "persistent": false
   },


### PR DESCRIPTION
## Summary
- update extension manifest to no longer specify `run_at` in the background config

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d371497fc8326bdd4e1c6c9f35d62