### PR TITLE
Update manifest with Gecko ID

### DIFF
--- a/DiscoEnhancements/manifest.json
+++ b/DiscoEnhancements/manifest.json
@@ -4,6 +4,9 @@
   "name": "Disco Enhancements for BMC Discovery (DEV)",
   "description": "This exension provides some powerful enhancements to the BMC Discovery UI.",
   "version": "1.6",
+  "applications": {
+    "gecko": { "id": "discoenhancements@example.com" }
+  },
   "author": "Wes Moskal-Fitzpatrick (Traversys)",
   "short_name": "Disco Enhancements",
 


### PR DESCRIPTION
## Summary
- add `applications` with a Gecko extension ID so the addon can be installed in Firefox

## Testing
- `firefox --version` *(fails: Command requires the Firefox snap to be installed)*
- `web-ext run -s DiscoEnhancements --firefox=firefox` *(fails to start Firefox)*

------
https://chatgpt.com/codex/tasks/task_e_686d3c2ae6148326a5988d08155c79f6