### PR TITLE
Limit extension host access

### DIFF
--- a/DiscoEnhancements/manifest.json
+++ b/DiscoEnhancements/manifest.json
@@ -12,8 +12,7 @@
   },
 
   "permissions": [
-    "http://*/*",
-    "https://*/*",
+    "*://*/ui/*",
     "activeTab",
     "storage"
   ],
@@ -25,7 +24,7 @@
   },
 
   "content_scripts": [{
-    "matches": ["http://*/*", "https://*/*"],
+    "matches": ["*://*/ui/*"],
     "js": ["content.js"]
   }],
 


### PR DESCRIPTION
## Summary
- restrict extension host permissions to BMC Discovery URLs
- match content scripts only on BMC Discovery pages

## Testing
- `xvfb-run -a node test_extension.js` *(fails to load manifest v2 extension)*

------
https://chatgpt.com/codex/tasks/task_e_686d3dee429c83269bf757e264cc802b