### PR TITLE
Fix refine results style check

### DIFF
--- a/DiscoEnhancements/content.js
+++ b/DiscoEnhancements/content.js
@@ -210,11 +210,11 @@ function refineResults() {
         newRefineTop.setAttribute('id', 'discoRefineTop');
         container.appendChild(newRefineTop);
         container.style.cssText = "text-align:right; float:none;";
-        var resultsTable = document.getElementsByClassName('actionCaption')[0];
-        if (!resultsTable) {
-          var resultsTable = document.getElementById('resultsCaption');
+        let resultsTable = document.querySelector('.actionCaption') ||
+                           document.getElementById('resultsCaption');
+        if (resultsTable) {
+          resultsTable.style.cssText = "padding-bottom: 50px;";
         }
-        resultsTable.style.cssText = "padding-bottom: 50px;";
       }
     } else if (!data["refine_results"] && refineTop) {
       refineTop.remove();


### PR DESCRIPTION
## Summary
- avoid errors in `refineResults` when the results caption elements are missing

## Testing
- `node test.js` (no results table)
- `node test2.js` (with results table)

------
https://chatgpt.com/codex/tasks/task_e_686d40b433d0832697349df68ae03974