### PR TITLE
Fix misspelling in manifest description

### DIFF
--- a/DiscoEnhancements/manifest.json
+++ b/DiscoEnhancements/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "Disco Enhancements for BMC Discovery (DEV)",
-  "description": "This exension provides some powerful enhancements to the BMC Discovery UI.",
+  "description": "This extension provides some powerful enhancements to the BMC Discovery UI.",
   "version": "1.6",
   "author": "Wes Moskal-Fitzpatrick (Traversys)",
   "short_name": "Disco Enhancements",


### PR DESCRIPTION
## Summary
- correct the word `exension` to `extension` in the extension description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d419ab5d48326b58d54e2c5f0d33f